### PR TITLE
Fix backslashing of deps keys in Windows

### DIFF
--- a/lib/getAppModules.js
+++ b/lib/getAppModules.js
@@ -16,7 +16,7 @@ module.exports = (containerRoot, substitutes) => {
   walker.on('file', (dir, fileStat, next) => {
     const parsedModulePath = parse(join(dir, fileStat.name));
     const relativePath = relative(containerRoot, dir);
-    const moduleKey = getModuleKey(relativePath, parsedModulePath);
+    const moduleKey = getModuleKey(relativePath.replace(/\\/g, '/'), parsedModulePath);
 
     if (substitutes.every(substitute => substitute !== moduleKey)) {
       Object.defineProperty(customModules, moduleKey, {


### PR DESCRIPTION
In Windows, `path` resolves directory separators as `\` instead of `/`, messing up the deps keys. This fix normalises to `/`
