### PR TITLE
Unhandled promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,6 @@ module.exports = (options) => {
     })
     .catch((err) => {
       e(err);
-
-      return Promise.reject(err);
+      throw new Error(err);
     });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "breadboard",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "description": "Lightweight IOC container for Node.js",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "breadboard",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "description": "Lightweight IOC container for Node.js",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
 prevent 
```
(node:15720) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): TypeError: Invalid data, chunk must be a string or buffer, not undefined

```

This is needed for when breadboard can not find the correct directory in order to start.

The previous method (to use `promise.reject`) is incorrect.
